### PR TITLE
feat: add automatic schedule fetch on app load and entity change

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Uses [NureTimetableAPI](https://github.com/music-soul1-1/NureTimetableAPI).
 
 
 ## Plans
-- automate or remove schedule date picker (so that the app shows schedule for current semester automatically)
 - change app icons for Linux
 - refactor and optimize code
 - update some dependencies

--- a/lib/locales/locales.dart
+++ b/lib/locales/locales.dart
@@ -118,7 +118,7 @@ mixin AppLocale {
     resetSettings: "Reset settings",
     noData: "No data",
     error: "Error",
-    noConnectionToInternet: "No connection to internet",
+    noConnectionToInternet: "No connection to the Internet",
     nextLesson: "Next lesson",
     noLessonsInNearFuture: "No lessons in the near future",
     previousWeek: "Previous week",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,6 +38,7 @@ import 'theme/theme_manager.dart';
 var _themeManager = ThemeManager();
 var _settingsManager = SettingsManager();
 final FlutterLocalization localization = FlutterLocalization.instance;
+ValueNotifier<bool> scheduleFetchedNotifier = ValueNotifier<bool>(false);
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -46,6 +47,10 @@ void main() async {
   
   runApp(const MyApp());
   initializeDateFormatting(localization.currentLocale?.languageCode == "uk" ? 'uk_UA' : 'en_UK');
+
+  WidgetsBinding.instance.addPostFrameCallback((_) async {
+    scheduleFetchedNotifier.value = true;
+  });
 }
 
 
@@ -93,13 +98,7 @@ class _MyAppState extends State<MyApp> {
     }
   }
 
-  settingsListener() {
-    if (mounted) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        //setState(() {});
-      });
-    }
-  }
+  settingsListener() {}
 
 
   @override
@@ -118,8 +117,8 @@ class _MyAppState extends State<MyApp> {
           child: Scaffold(
             body: TabBarView(
               children: [
-                HomePage(settingsManager: _settingsManager, themeManager: _themeManager),
-                GroupsPage(settingsManager: _settingsManager, themeManager: _themeManager),
+                HomePage(settingsManager: _settingsManager, themeManager: _themeManager, scheduleFetchedNotifier: scheduleFetchedNotifier,),
+                GroupsPage(settingsManager: _settingsManager, themeManager: _themeManager, scheduleFetchedNotifier: scheduleFetchedNotifier),
                 SettingsPage(settingsManager: _settingsManager, themeManager: _themeManager, localization: localization),
               ],
             ),

--- a/lib/models/update_info.dart
+++ b/lib/models/update_info.dart
@@ -18,37 +18,41 @@ class UpdateInfo {
 }
 
 /// Returns the latest version of the app.
-Future<UpdateInfo> getLatestVersion() async {
-  const String url = 'https://api.github.com/repos/music-soul1-1/nure-timetable/releases/latest';
+Future<UpdateInfo?> getLatestVersion() async {
+  try {
+    const String url = 'https://api.github.com/repos/music-soul1-1/nure-timetable/releases/latest';
 
-  var response = await http.get(Uri.parse(url));
+    var response = await http.get(Uri.parse(url));
 
-  if (response.statusCode == 200) {
-    final json = jsonDecode(response.body);
+    if (response.statusCode == 200) {
+      final json = jsonDecode(response.body);
 
-    final mode = JSON.parse(response.body);
-    final assets = mode['assets'].listValue;
-    
-    final apkDownloadUrl = assets
-        .firstWhere((element) => element['browser_download_url']
-            .stringValue
-            .contains('apk'))['browser_download_url']
-            .stringValue;
-    final exeDownloadUrl = assets
-        .firstWhere((element) => element['browser_download_url']
-            .stringValue
-            .contains('exe'))['browser_download_url']
-            .stringValue;
+      final mode = JSON.parse(response.body);
+      final assets = mode['assets'].listValue;
+      
+      final apkDownloadUrl = assets
+          .firstWhere((element) => element['browser_download_url']
+              .stringValue
+              .contains('apk'))['browser_download_url']
+              .stringValue;
+      final exeDownloadUrl = assets
+          .firstWhere((element) => element['browser_download_url']
+              .stringValue
+              .contains('exe'))['browser_download_url']
+              .stringValue;
 
-    return UpdateInfo(
-      version: json['tag_name'],
-      apkDownloadUrl: apkDownloadUrl,
-      exeDownloadUrl: exeDownloadUrl,
-      url: json['html_url'],
-    );
+      return UpdateInfo(
+        version: json['tag_name'],
+        apkDownloadUrl: apkDownloadUrl,
+        exeDownloadUrl: exeDownloadUrl,
+        url: json['html_url'],
+      );
+    }
+
+    return null;
   }
-  else {
-    throw Exception('Failed to load latest version');
+  catch (e) {
+    throw Exception('Failed to load latest version: $e');
   }
 }
 

--- a/lib/pages/groups_page.dart
+++ b/lib/pages/groups_page.dart
@@ -17,10 +17,16 @@ var isMobile = !kIsWeb && (Platform.isAndroid || Platform.isIOS);
 
 
 class GroupsPage extends StatefulWidget {
-  const GroupsPage({super.key, required this.settingsManager, required this.themeManager});
+  const GroupsPage({
+    super.key, 
+    required this.settingsManager, 
+    required this.themeManager,
+    required this.scheduleFetchedNotifier,
+  });
 
   final ThemeManager themeManager;
   final SettingsManager settingsManager;
+  final ValueNotifier<bool> scheduleFetchedNotifier;
 
   @override
   State<GroupsPage> createState() => _GroupsPageState();
@@ -169,6 +175,8 @@ class _GroupsPageState extends State<GroupsPage> {
                               duration: const Duration(seconds: 1),
                             );
                             ScaffoldMessenger.of(context).showSnackBar(snackbar);
+
+                            widget.scheduleFetchedNotifier.value = false; // Makes the app update schedule from the API when going back to home page
                           }
                           catch(error) {
                             showErrorSnackbar(error.toString());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.2.0+34
+version: 2.2.1+35
 
 environment:
   sdk: '>=3.1.5 <4.0.0'


### PR DESCRIPTION
- add automatic schedule fetch on app load and entity change.
- add error snackbar for update check button.
- move schedule fetch & saving logic to SettingsManager in loadSchedule function.
- update app version to 2.2.1+35.