### PR TITLE
feat(ui): add snackbar for background schedule update

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.2.3+37
+version: 2.2.4+38
 
 environment:
   sdk: '>=3.1.5 <4.0.0'


### PR DESCRIPTION
- schedule update snackbar moved to `_loadSettings(),` therefore now it's showing on app start too.
- app version updated to `2.2.4+38`